### PR TITLE
Update for Anaconda CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Ignore all files and folders in root
 *
+!/abs.yaml
 !/conda-forge.yml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,6 +8,8 @@ mkdir build
 cd build
 cmake %CMAKE_ARGS% ^
   -G Ninja ^
+  -D CMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+  -D CMAKE_BUILD_TYPE=Release ^
   -D BUILD_SHARED_LIBS=ON ^
   -D BUILD_TRANSPORT_WINHTTP=ON ^
   ..

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,8 +18,9 @@ cd sdk/core/azure-core
 mkdir build
 cd build
 cmake $CMAKE_ARGS \
-  -D CMAKE_BUILD_TYPE=Release \
   -G Ninja \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_BUILD_TYPE=Release \
   -D BUILD_SHARED_LIBS=ON \
   -D BUILD_TRANSPORT_CURL=ON \
   ..

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "1.14.1" %}
-{% set sha256 = "e0173a675363463c63f52a215e4b3f1bfb28c901d70fe7eea420b5dc4aa591cb" %}
 
 package:
   name: azure-core-cpp
@@ -7,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-core_{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: e0173a675363463c63f52a215e4b3f1bfb28c901d70fe7eea420b5dc4aa591cb
   patches:
     # https://github.com/Azure/azure-sdk-for-cpp/issues/4784
     # https://github.com/Azure/azure-sdk-for-cpp/pull/4785
@@ -22,13 +21,14 @@ build:
 requirements:
   build:
     - {{ compiler("cxx") }}
-    - {{ stdlib("c") }}
     - cmake
     - ninja
+    - patch     # [unix]
+    - m2-patch  # [win]
   host:
-    - libcurl  # [not win]
-    - openssl  # [not win]
-    - wil  # [win]
+    - libcurl {{ libcurl }}  # [unix]
+    - openssl {{ openssl }}  # [unix]
+    - wil 1.0                # [win]
 
 test:
   requires:


### PR DESCRIPTION
azure-core-cpp 1.14.1

**Destination channel:** defaults

### Links

- [PKG-8075](https://anaconda.atlassian.net/browse/PKG-8075)
- [Upstream repository](https://github.com/Azure/azure-sdk-for-cpp/tree/azure-core_1.14.1/sdk/core/azure-core)
- Relevant dependency PRs:
  - AnacondaRecipes/wil-feedstock#1

### Explanation of changes:

- Initial build of forked conda-forge recipe


[PKG-8075]: https://anaconda.atlassian.net/browse/PKG-8075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ